### PR TITLE
Fix wrong url for purge

### DIFF
--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -164,7 +164,7 @@ class Aoe_Static_Helper_Data extends Mage_Core_Helper_Abstract
               $ch = curl_init();
               $this->log('Purge url: ' . $url);
               $options = array(
-                  CURLOPT_URL => $purgeHost . $components['path'],
+                  CURLOPT_URL => $url,
                   CURLOPT_HTTPHEADER => array('Host: ' . $components['host'])
               );
 


### PR DESCRIPTION
Before the URL contained `/index.php` and sometimes `//` which doesn't work since the actual URL is without the `index.php` or `//` parts and hence not purged.
