### PR TITLE
Global messages support

### DIFF
--- a/code/Block/Core/Messages.php
+++ b/code/Block/Core/Messages.php
@@ -6,6 +6,6 @@ class Aoe_Static_Block_Core_Messages extends Mage_Core_Block_Messages
         if (!Mage::helper('aoestatic')->cacheContent()) {
             return parent::getGroupedHtml();
         }
-        return '<div class="placeholder" rel="messages"></div>';
+        return sprintf('<div class="placeholder" rel="%s"></div>', $this->getNameInLayout());
     }
 }

--- a/code/controllers/CallController.php
+++ b/code/controllers/CallController.php
@@ -40,6 +40,8 @@ class Aoe_Static_CallController extends Mage_Core_Controller_Front_Action
                 if ($tmpBlock) {
                     if($requestedBlockName == 'messages'){
                         $response['blocks'][$id] = $layout->getMessagesBlock()->getGroupedHtml();
+                    }elseif($requestedBlockName == 'global_messages'){
+                        $response['blocks'][$id] = $tmpBlock->getGroupedHtml();
                     }else{
                         $response['blocks'][$id] = $tmpBlock->toHtml();
                     }


### PR DESCRIPTION
Instead of loading block 'messages' twice, recognize block name ('global_messages' or 'messages') and request corresponding block contents.
