### PR TITLE
Fix cron execution of removeExpiredUrls

### DIFF
--- a/code/Model/Url.php
+++ b/code/Model/Url.php
@@ -72,7 +72,7 @@ class Aoe_Static_Model_Url extends Mage_Core_Model_Abstract
      *
      * @return Aoe_Static_Model_Url
      */
-    protected function deleteExistingTags()
+    public function deleteExistingTags()
     {
         $collection = Mage::getModel('aoestatic/urltag')->getCollection()
             ->addFieldToFilter('url_id', $this->getId());


### PR DESCRIPTION
On executing the cron, we got the following error regularly:

```
`exception 'Varien_Exception' with message 'Invalid method Aoe_Static_Model_Url::deleteExistingTags(Array
(
)
)' in /path/to/magento/lib/Varien/Object.php:652
Stack trace:
#0 /path/to/magento/app/code/local/Aoe/Static/Model/Cache.php(241): Varien_Object->__call('deleteExistingT...', Array)
#1 /path/to/magento/app/code/local/Aoe/Static/Model/Cache.php(241): Aoe_Static_Model_Url->deleteExistingTags()
#2 [internal function]: Aoe_Static_Model_Cache->removeExpiredUrls(Object(Aoe_Scheduler_Model_Schedule))
#3 /path/to/magento/app/code/local/Aoe/Scheduler/Model/Observer.php(75): call_user_func_array(Array, Array)
#4 /path/to/magento/app/code/core/Mage/Core/Model/App.php(1303): Aoe_Scheduler_Model_Observer->dispatch(Object(Varien_Event_Observer))
#5 /path/to/magento/app/code/core/Mage/Core/Model/App.php(1284): Mage_Core_Model_App->_callObserverMethod(Object(Aoe_Scheduler_Model_Observer), 'dispatch', Object(Varien_Event_Observer))
#6 /path/to/magento/app/Mage.php(416): Mage_Core_Model_App->dispatchEvent('default', Array)
#7 /path/to/magento/cron.php(49): Mage::dispatchEvent('default')
#8 {main}
```

We got that fixed by setting the method from `protected` to `public`.
