### PR TITLE
Use DELETE instead of TRUNCATE to flush cache tables

### DIFF
--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -120,7 +120,7 @@ class Aoe_Static_Helper_Data extends Mage_Core_Helper_Abstract
         $conn = Mage::getSingleton('core/resource')->getConnection('core_write');
         foreach (array('url', 'tag', 'urltag') as $table) {
             $resource = Mage::getResourceModel('aoestatic/' . $table);
-            $conn->query(sprintf('TRUNCATE %s;', $resource->getMainTable()));
+            $conn->query(sprintf('DELETE FROM %s;', $resource->getMainTable()));
         }
         return $this->purge(array($baseUrl . '.*'));
     }


### PR DESCRIPTION
I use aoe_static and aoe_cleaner in the same shop and got an hourly cron exception mail, complaining about that:

```
exception 'PDOException' with message 'SQLSTATE[42000]: Syntax error or access violation: 1701 Cannot truncate a table referenced in a foreign key constraint (`databasename`.`aoe_static_urltag`, CONSTRAINT `FK_AOE_STATIC_URLTAG_URL_ID_AOE_STATIC_URL_URL_ID` FOREIGN KEY (`url_id`) REFERENCES `databasename`.`aoe_static_url` (`url_id`))' in /html/production/current/lib/Zend/Db/Statement/Pdo.php:228.
```

I know `aoe_static_url`, `aoe_static_tag`, and `aoe_static_urltag` to be InnoDB tables, so I had a look at MySQL docs, that confirmed, that `TRUNCATE` on `aoe_static_urltag` should fall back to a line-by-line `DELETE`, while deleting foreign-key rows from `aoe_static_tag` and `aoe_static_url` as well (thanks to `ON DELETE CASCADE` in `aoe_static_urltag`.

Actually, this did not work as expected, so I got the exception mentioned above.

So I changed `TRUNCATE` to `DELETE FROM` and it works now like a charm. If you have any idea, why `TRUNCATE` did not work, let me please know about that.
