### PR TITLE
Redirect if no ajax

### DIFF
--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -120,7 +120,7 @@ class Aoe_Static_Helper_Data extends Mage_Core_Helper_Abstract
         $conn = Mage::getSingleton('core/resource')->getConnection('core_write');
         foreach (array('url', 'tag', 'urltag') as $table) {
             $resource = Mage::getResourceModel('aoestatic/' . $table);
-            $conn->query(sprintf('TRUNCATE %s;', $resource->getMainTable()));
+            $conn->query(sprintf('DELETE FROM %s;', $resource->getMainTable()));
         }
         return $this->purge(array($baseUrl . '.*'));
     }

--- a/code/controllers/CallController.php
+++ b/code/controllers/CallController.php
@@ -16,7 +16,9 @@ class Aoe_Static_CallController extends Mage_Core_Controller_Front_Action
      */
     public function indexAction()
     {
-        // if (!$this->getRequest()->isXmlHttpRequest()) { Mage::throwException('This is not an XmlHttpRequest'); }
+        if (!$this->getRequest()->isXmlHttpRequest()) {
+            return $this->_redirect('/');
+        }
 
         $response = array();
         $response['sid'] = Mage::getModel('core/session')->getEncryptedSessionId();


### PR DESCRIPTION
In Magento, you get redirected to the last visited page after login. Using Aoe_Static this may result in an raw AJAX response after login, which will irritate customers.

Using this patch, users will get redirected to homepage in this situation instead.
